### PR TITLE
fix(contributing): error in server.js path in code example

### DIFF
--- a/src/documents/hack/contributing/index.html.md
+++ b/src/documents/hack/contributing/index.html.md
@@ -102,7 +102,7 @@ The --no-bin-links is needed because you can't symlink in the shared folder.
     git clone https://github.com/cozy/cozy-home
     cd /vagrant/cozy-home
     sudo npm install --no-bin-links
-    node server.js
+    node build/server.js
     ```
 
 6. On the host, browse to http://127.0.0.1:9104, register a user, and then check http://127.0.0.1:9104/#home.


### PR DESCRIPTION
There was an error in "contributing" section code example.
While in /vagrant/cozy-home, we have to type node build/server.js to launch the built version of server.coffee