### PR TITLE
removing the space after the escaping backslash

### DIFF
--- a/src/documents/fr/host/install/install-on-ubuntu.html.md
+++ b/src/documents/fr/host/install/install-on-ubuntu.html.md
@@ -34,7 +34,7 @@ Codename:     trusty
     ```
 3. Ajoutez le dépôt Cozy à vos sources de logiciels.
     ```
-    echo 'deb https://ubuntu.cozycloud.cc/debian trusty main' \ 
+    echo 'deb https://ubuntu.cozycloud.cc/debian trusty main' \
         | sudo tee /etc/apt/sources.list.d/cozy.list > /dev/null
     ```
 4. Installez Cozy


### PR DESCRIPTION
it was escaping the space instead of the line break, thus throwing an error: `-bash: syntax error near unexpected token `|'`