### PR TITLE
Added the link to the index, and added a title to have a nice vertical offset

### DIFF
--- a/src/documents/en/host/install/index.html.md
+++ b/src/documents/en/host/install/index.html.md
@@ -27,6 +27,9 @@ A minimum amount of RAM is required though: **1024MB** is a good start for 6 Coz
   <a href="install-on-debian.html">
     ![Debian](/assets/images/debian-logo.png)<div class="label">Debian (64 bits)</div>
   </a>
+  <a href="install-on-archlinux.html">
+    ![Archlinux](/assets/images/archlinux-logo.png)<div class="label">Archlinux</div>
+  </a>
 </div>
 
 ## on your hardware

--- a/src/documents/en/host/install/install-on-archlinux.html.md
+++ b/src/documents/en/host/install/install-on-archlinux.html.md
@@ -13,6 +13,8 @@ toc: false
 
 # Install Cozy on Archlinux
 
+## Warning
+
 Cozy packages are available on the **AUR** (*Archlinux User Repository*) repository, which is not natively supported by Archlinux. In order to install Cozy, you will need an AUR helper, preferably among the ones listed [here](https://wiki.archlinux.org/index.php/AUR_helpers).
 
 In this documentation, we'll be using **Yaourt**, which you can install following [these instructions](https://archlinux.fr/yaourt-en).

--- a/src/documents/fr/host/install/index.html.md
+++ b/src/documents/fr/host/install/index.html.md
@@ -27,6 +27,9 @@ Un minimum de RAM est tout de même recommandé: **1024 Mo** semble être un bon
   <a href="install-on-debian.html">
     ![Debian](/assets/images/debian-logo.png)<div class="label">Debian (64 bits)</div>
   </a>
+  <a href="install-on-archlinux.html">
+    ![Archlinux](/assets/images/archlinux-logo.png)<div class="label">Archlinux</div>
+  </a>
 </div>
 
 ## sur votre matériel

--- a/src/documents/fr/host/install/install-on-archlinux.html.md
+++ b/src/documents/fr/host/install/install-on-archlinux.html.md
@@ -13,6 +13,8 @@ toc: false
 
 # Installer Cozy sur Archlinux
 
+## Avertissement
+
 Les paquets de Cozy sont disponibles sur le dépôt d'utilisateurs d'Archlinux, ou **AUR** (pour *Archlinux User Repository*). Ce dépôt n'est pas supporté nativement, il vous faudra donc installer un utilitaire vous permettant d'y accéder, parmi la liste disponible [ici](https://wiki.archlinux.org/index.php/AUR_helpers). 
 
 Dans cette documentation, nous utiliserons **Yaourt**, que vous pouvez installer en suivant les instructions disponibles [ici](https://archlinux.fr/yaourt).


### PR DESCRIPTION
While refreshing the index at https://cozy.io/en/host/install/, I realised I forgot to add Archlinux's documentation to the said index. On top of that, I observed that the text was overlaying the Archlinux logo on the doc, so I added a title to make use of its vertical offset.