### PR TITLE
Documentation to put self signed certificate in Android with CADroid.

### DIFF
--- a/src/documents/en/mobile/trouble.html.md
+++ b/src/documents/en/mobile/trouble.html.md
@@ -30,10 +30,24 @@ Here’s how to send the logs:
 
 
 ## Note about self-signed certificates
-About Self hosted instances, you probably have a self-signed certificate.
-Cozy Mobile won't recognize it until you validate it on your mobile. See
-[there](http://davdroid.bitfire.at/faq/entry/importing-a-certificate)
-for instruction on how to do it.
+About Self hosted instances, you probably have a self-signed certificate. You have to install it on your Android device, to allow Cozy Mobile to recognize it.
+
+1. Install on your Android device the application [CADroid](https://cadroid.bitfire.at/), which will help you in this task (from the [PlayStore](https://play.google.com/store/apps/details?id=at.bitfire.cadroid) or [FDroid](https://f-droid.org/repository/browse/?fdfilter=cadroid&fdid=at.bitfire.cadroid).
+2. Run the CADroid application, then touch **Next** (in the upper right corner).
+3. Type your cozy URL, then touch **Fetch**.
+4. Select your certificate, check it informations and that CADroid didn't find any issue with it, then touch **Next**.
+5. CADroid has just exported your certificate in the root of the SD card of your device. Note the filename ! CADroid converted the certificat in the format expected by Android. Touch Next to get some informations from CADroid.
+6. Then, still on your ANdroid device, go to Settings/Security/**Install from device storage** (in the _Credential storage_ section).
+7. Browse to find your certificate, exported in step 5, and select it.
+8. Android will then ask you a certificate name (doesn't matter), and to chose the use of your certificate. Select _VPN and Applications_. Android may also ask you to upgrade the access sécurity level of your device (adding a unlocking  schema, ...).
+
+Now, your certificate will be accepted by any applications on your device !
+
+Complements:
+* Android ask to upgrade the access security level. It looks strange, but apparently Android thinks there's a client certificate with a private key that must be protected.
+* On Android 4.4+ devices, there'll be an annoying hint _Network may be monitored_ on each device start. This an [Android bug](https://code.google.com/p/android/issues/detail?id=62076).
+
+_Thanks to the DavDroid team, for CADroid and elements for this documentation !_
 
 ## I don't have an Android Phone
 Let us know on the [forum](https://forum.cozy.io/) you would like to see the application for your system!

--- a/src/documents/fr/mobile/trouble.html.md
+++ b/src/documents/fr/mobile/trouble.html.md
@@ -30,12 +30,27 @@ Pour envoyer ces informations :
  * Et enfin, envoyez le mails.
 
 ## A propos des certificats auto-signés
-A propos des Cozy auto-hébergé : vous avez probablement un certificat SSL auto-signé.
-L'application mobile Cozy ne le reconnaîtra pas avant qu'il soit validé sur votre mobile. Suivez les instructions
-[suivantes (en)](http://davdroid.bitfire.at/faq/entry/importing-a-certificate) pour savoir comment faire.
+A propos des Cozy auto-hébergé : vous avez probablement un certificat SSL auto-signé. Celui-ci doit être ajouté à votre terminal Android pour être reconnu par l'application mobile Cozy. Pour ce faire :
+
+1. Installez sur votre terminal Android l'application [CADroid](https://cadroid.bitfire.at/), qui va vous assister dans cette tâche (sur le [PlayStore](https://play.google.com/store/apps/details?id=at.bitfire.cadroid) ou sur [FDroid](https://f-droid.org/repository/browse/?fdfilter=cadroid&fdid=at.bitfire.cadroid))
+2. Lancez l'application CADroid, puis toucher **Next** (dans le coin en haut à droite).
+3. Entrez l'url de votre Cozy, puis touchez **Fetch**.
+4. Sélectionez votre certificat, vérifiez ses informations et que CADroid ne vous notifie pas d'erreurs, puis touchez **Next**.
+5. CADroid vient d'exporter votre certificat à la racine de la carte SD de votre terminal. Pensez-à noter le nom du fichier ! Le certificat a été converti dans le format attendu par Android. Vous pouvez toucher Next pour visualiser quelques explication de la part de CADroid.
+6. Ensuite, toujours sur votre terminal Android, rendez-vous dans Paramètres/Sécurité/**Installer depuis la carte SD** (dans la section _Stockage des identifiants_).
+7. Parcourez l'arborescence pour retrouver le certificat exporté à l'étape 5, et sélectionnez-le.
+8. Android vous demande alors de donner un nom au certificat (sans importance), et de choisir son usage. Il faut choisir _VPN et Application_ dans notre cas. De plus Android peut éventuellement vous demander d'augmenter le niveau de sécurité d'accès à votre terminal (ajouter un schéma de débloquage, ...).
+
+Votre certificat sera désormais accepté par les applications de votre terminal Android !
+
+Informations complémentaires :
+* Android demande d'augmenter le niveau de sécurité d'accès au terminal. Cela semble incongrue, mais apparemment, Android immagine que ces certificats contiennent des clés privé qu'il faudrait protéger.
+* Sur Android 4.4 et supérieurs, suite à l'ajout du certificat, une notification _Il est possible que le réseau soit surveillé. Par un tier inconnu_ apparait au démarrage du terminal. C'est un [bug d'Android](https://code.google.com/p/android/issues/detail?id=62076).
+
+_Remerciements à l'équpe DavDroid pour l'application CADroid, et beaucoup d'inspiration pour cette documentation !_
 
 ## Je n'ai pas de périphérique Android
-Faites-nous savoir sur le [forum](https://forum.cozy.io/) que que voudriez avoir l'application sur votre système !
+Faites-nous savoir sur le [forum](https://forum.cozy.io/) que vous voudriez avoir l'application sur votre système !
 
 ## Ressources connectées
 * [Page du Playstore](https://play.google.com/store/apps/details?id=io.cozy.files_client&hl=)


### PR DESCRIPTION
Note : docpad-plugin-tableofcontents cause "TypeError: Cannot read property 'implementation' of undefined" on npm start. I didn't fix it.
