### PR TITLE
Fix ssh login to vagrant for "Install on VirtualBox"

### DIFF
--- a/src/documents/en/host/install/install-on-virtualbox.html.md
+++ b/src/documents/en/host/install/install-on-virtualbox.html.md
@@ -47,5 +47,5 @@ You can find the box' IP with the `ifconfig` command.
 You can connect through ssh with:
 
 ```bash
-ssh -p 2222 root@localhost
+ssh -p 2222 vagrant@localhost
 ```

--- a/src/documents/fr/host/install/install-on-virtualbox.html.md
+++ b/src/documents/fr/host/install/install-on-virtualbox.html.md
@@ -44,5 +44,5 @@ Ouvrez le port 22 de votre machine virtuelle vers 127.0.0.1:2222, et le port 443
 * Connectez-vous en SSH à l'aide de cette commande :
 
 ```bash
-ssh -p 2222 root@localhost
+ssh -p 2222 vagrant@localhost
 ```


### PR DESCRIPTION
The command line to connect to a VirtualBox Cozy instance through ssh used root although the credentials was vagrant/vagrant. Fixed.