### PR TITLE
Updated Archlinux instructions

### DIFF
--- a/src/documents/en/host/install/install-on-archlinux.html.md
+++ b/src/documents/en/host/install/install-on-archlinux.html.md
@@ -13,62 +13,6 @@ toc: false
 
 # Install Cozy on Archlinux
 
-## Warning
+Cozy's installation instructions on Archlinux are explained and kept up to date on [the related ArchWiki page](https://wiki.archlinux.org/index.php/Cozy).
 
-The Cozy package is available on the **AUR** (*Archlinux User Repository*) repository, which is not natively supported by Archlinux. In order to install Cozy, you will need an AUR helper, preferably among the ones listed [here](https://wiki.archlinux.org/index.php/AUR_helpers).
-
-In this documentation, we'll be using **Yaourt**, which you can install following [these instructions](https://archlinux.fr/yaourt-en).
-
-## Installing
-
-Once Yaourt is installed, please enter the following command:
-
-```
-yaourt -S cozy
-```
-
-Unless you want to hack the package, please answer "no" when being asked if you want to edit the files `PKGBUILD` and `cozy.install`, and "yes" when being asked if you want to compile the package.
-
-Once both the dependencies' installation and the package's creation is over, Yaourt will display the following message:
-
-```
-==> Install cozy ? [Y/n]
-```
-
-Please answer it with a positive answer. Cozy's stack installation and configuration will then begin.
-
-## Configuring
-
-Once the package is installed, Cozy won't instantly be usable. Before that, you will have to configure your Cozy's domain name and a [reverse proxy](https://en.wikipedia.org/wiki/Reverse_proxy).
-
-### Configuring the domain name
-
-The package comes with a script allowing the user to easily set Cozy's domain name and generate the needed certificates. You can run it with
-
-```
-sudo configure-cozy-domain cozy.example.tld
-```
-
-where you will replace `cozy.example.tld` with your Cozy's domain name.
-
-This script can also be run whenever you wish to change your Cozy's domain name.
-
-### Configuring the reverse proxy
-
-In order for Cozy to work, it is necessary to use a reverse proxy. It can be a Web server or any software including this feature.
-
-Among the software able to act as a reverse proxy, we have [Apache](https://wiki.archlinux.org/index.php/Apache_HTTP_Server) or [nginx](https://wiki.archlinux.org/index.php/Nginx), for which configurations examples are available ([here](https://github.com/cozy/cozy-debian/blob/master/apache-config) for Apache and [here](https://github.com/cozy/cozy-debian/blob/master/nginx-config) for nginx).
-
-## Troubleshooting
-
-If you encounter any issue during the installation, please open an issue on [GitHub](https://github.com/babolivier/cozy-archlinux) or on [the Cozy forum](https://forum.cozy.io/t/cozy-on-archlinux/1342).
-
-### Conflict between `nodejs` and `nodejs-lts-bin`
-
-In order to run Cozy, we need to install Node.JS v4.x.x (LTS), located in the `nodejs-lts-bin` AUR package.
-
-Unfortunately, if Node.JS is already installed on your machine with the `nodejs` official package, a conflict will appear between it and `nodejs-lts-bin`. All you have to do to solve this issue is hitting "y" (letter can vary according to the system language, but you get it) when the installer asks you if you want to replace `nodejs` and `npm`.
-
-### How to regenerate the certificate?
-
-    sudo openssl req -x509 -nodes -newkey rsa:2048 -keyout /etc/cozy/server.key -out /etc/cozy/server.crt -days 3650 -subj "/CN=YOUR.INSTANCE.URL"
+This is a community port, not officially supported by Cozy. If you have any problem with it, please ask on [IRC](https://webchat.freenode.net/?channels=cozycloud), on the [forum](https://forum.cozy.io), or on this port's [GitHub repository](https://github.com/babolivier/cozy-archlinux).

--- a/src/documents/fr/host/install/install-on-archlinux.html.md
+++ b/src/documents/fr/host/install/install-on-archlinux.html.md
@@ -13,63 +13,7 @@ toc: false
 
 # Installer Cozy sur Archlinux
 
-## Avertissement
+Les instructions d'intallation de Cozy sur Archlinux sont détaillées et maintenues à jour sur [la page consacrée du ArchWiki](https://wiki.archlinux.org/index.php/Cozy) (en anglais).
 
-Le paquet Cozy est disponible sur le dépôt d'utilisateurs d'Archlinux, ou **AUR** (pour *Archlinux User Repository*). Ce dépôt n'est pas supporté nativement, il vous faudra donc installer un utilitaire vous permettant d'y accéder, parmi la liste disponible [ici](https://wiki.archlinux.org/index.php/AUR_helpers).
-
-Dans cette documentation, nous utiliserons **Yaourt**, que vous pouvez installer en suivant les instructions disponibles [ici](https://archlinux.fr/yaourt).
-
-## L'installation
-
-Une fois Yaourt installé, entrez la commande suivante :
-
-```
-yaourt -S cozy
-```
-
-A moins que vous ne souhaitiez bidouiller le paquet, répondez par la négative quand on vous demande si vous voulez modifier les fichiers `PKGBUILD` et `cozy.install`, et par l'affirmative lorsqu'on vous demande si vous souhaitez lancer la compilation du paquet.
-
-Une fois l'installation des dépendances et la création du paquet terminées, Yaourt vous affichera le message suivant :
-
-```
-==> Installer cozy ? [O/n]
-```
-Message auquel vous répondrez par l'affirmative.
-
-S'en suit la procédure d'installation des différents composants de Cozy.
-
-## Configuration initiale
-
-Une fois Cozy installé, il ne sera pas directement utilisable. Il faudra d'abord passer par la configuration du nom du domaine de Cozy et par la configuration d'un [*reverse proxy*](https://fr.wikipedia.org/wiki/Proxy_inverse).
-
-### Configuration du nom de domaine
-
-Le paquet installe un script permettant de modifier le nom de domaine associé à Cozy et de générer les certificats nécessaires à son bon fonctionnement. Il s'exécute avec la commande suivante :
-
-```
-sudo configure-cozy-domain cozy.example.tld
-```
-
-où on remplacera `cozy.example.tld` par le nom de domaine que l'on souhaite associer à Cozy.
-
-Ce script est utilisable chaque fois que vous souhaitez modifier le nom de domaine de votre Cozy.
-
-### Configuration d'un reverse proxy
-
-Afin de permettre le fonctionnement de Cozy, il est nécessaire d'utiliser un proxy inverse (ou *reverse proxy*). Ce dernier peut être un serveur Web ou n'importe quel programme exécutant cette fonction.
-
-Dans les logiciels permettant d'agir en tant que *reverse proxy*, on observe notamment Apache ou nginx, pour lesquels des exemples de configuration sont fournis ([ici](https://github.com/cozy/cozy-debian/blob/master/apache-config) pour Apache et [ici](https://github.com/cozy/cozy-debian/blob/master/nginx-config) pour nginx).
-
-## Que faire en cas de soucis
-
-Si vous rencontrez un soucis lors de l'installation, merci d'ouvrir un ticket sur [GitHub](https://github.com/babolivier/cozy-archlinux) ou sur [le forum Cozy](https://forum.cozy.io/t/cozy-sur-archlinux/1341).
-
-### Conflit entre `nodejs` et `nodejs-lts-bin`
-
-Afin de permettre le fonctionnement de Cozy, nous avons besoin de la version 4.x.x (LTS) de Node.JS, via le package AUR `nodejs-lts-bin`.
-
-Malheureusement, si vous avez déjà Node.JS d'installé sur votre machine via le paquet officiel `nodejs`, un conflit apparaitra lors de l'installation de `nodejs-lts-bin`. Afin de pallier ce problème, il vous suffit de répondre "o" (ou "oui") quand l'installateur vous demande si vous souhaitez remplacer `nodejs` et `npm`.
-
-### Comment re-générer le certificat ?
-
-    sudo openssl req -x509 -nodes -newkey rsa:2048 -keyout /etc/cozy/server.key -out /etc/cozy/server.crt -days 3650 -subj "/CN=URL.DE.VOTRE.INSTANCE"
+This is a community port, not officially supported by Cozy. If you have any problem with it, please ask on [IRC](https://webchat.freenode.net/?channels=cozycloud), on the [forum](https://forum.cozy.io), or on this port's [GitHub repository](https://github.com/babolivier/cozy-archlinux).
+Ce portage est maintenu par la communauté, et n'est pas officiellement supporté par Cozy. Si vous avez un soucis avec, n'hésitez pas à chercher de l'aide sur [IRC](https://webchat.freenode.net/?channels=cozycloud), sur le [forum](https://forum.cozy.io), ou sur son [dépôt GitHub](https://github.com/babolivier/cozy-archlinux).

--- a/src/documents/fr/host/install/install-on-archlinux.html.md
+++ b/src/documents/fr/host/install/install-on-archlinux.html.md
@@ -15,5 +15,4 @@ toc: false
 
 Les instructions d'intallation de Cozy sur Archlinux sont détaillées et maintenues à jour sur [la page consacrée du ArchWiki](https://wiki.archlinux.org/index.php/Cozy) (en anglais).
 
-This is a community port, not officially supported by Cozy. If you have any problem with it, please ask on [IRC](https://webchat.freenode.net/?channels=cozycloud), on the [forum](https://forum.cozy.io), or on this port's [GitHub repository](https://github.com/babolivier/cozy-archlinux).
 Ce portage est maintenu par la communauté, et n'est pas officiellement supporté par Cozy. Si vous avez un soucis avec, n'hésitez pas à chercher de l'aide sur [IRC](https://webchat.freenode.net/?channels=cozycloud), sur le [forum](https://forum.cozy.io), ou sur son [dépôt GitHub](https://github.com/babolivier/cozy-archlinux).


### PR DESCRIPTION
Archlinux install instructions have moved to the ArchWiki (easier to maintain, + there had to be a wiki page and it's useless and troublesome to have the same thing explained at several places at the same time).

Also added the "community port" mention.