### PR TITLE
Be more compatible with Debian package

### DIFF
--- a/src/documents/en/host/install/install-on-digitalocean.html.md
+++ b/src/documents/en/host/install/install-on-digitalocean.html.md
@@ -56,10 +56,10 @@ ssh root@server.ip
 
 ```
 # Import the repository public key
-wget -O - http://debian.cozycloud.cc/cozy.gpg.key 2>/dev/null | apt-key add -
+wget https://debian.cozycloud.cc/cozy.gpg.key -O /etc/apt/trusted.gpg.d/cozy.gpg
 
 # Add the Cozy repository to the software sources
-echo 'deb http://debian.cozycloud.cc/debian jessie cozy' \
+echo 'deb https://debian.cozycloud.cc/debian jessie cozy' \
  > /etc/apt/sources.list.d/cozy.list
 
 # Install Cozy

--- a/src/documents/en/host/install/install-on-ubuntu.html.md
+++ b/src/documents/en/host/install/install-on-ubuntu.html.md
@@ -34,7 +34,7 @@ Cozy needs a web server. By default, we will install and configure Nginx, but if
     ```
 2. Import the repository public key
     ```
-    wget -O - https://ubuntu.cozycloud.cc/cozy.gpg.key 2>/dev/null | sudo apt-key add -
+    wget https://debian.cozycloud.cc/cozy.gpg.key -O /etc/apt/trusted.gpg.d/cozy.gpg
     ```
 3. Add the Cozy repository to your software sources
     ```

--- a/src/documents/fr/host/install/install-on-debian.html.md
+++ b/src/documents/fr/host/install/install-on-debian.html.md
@@ -44,7 +44,7 @@ Cozy a besoin d’un serveur web. Par défaut, nous installons et configurons un
     ```
 2. Importez la clé publique du dépôt
     ```
-    wget -O - https://debian.cozycloud.cc/cozy.gpg.key 2>/dev/null | apt-key add -
+    wget https://debian.cozycloud.cc/cozy.gpg.key -O /etc/apt/trusted.gpg.d/cozy.gpg
     ```
 3. En option, vérifiez que la clé importée est valide
     ```
@@ -104,6 +104,6 @@ Les versions récentes de Cozy nécessitent nodejs 4.x, et Cozy est tellement sy
 Le problème, c'est que Debian 8 (Jessie) propose déjà, dans ses dépôts standards, une version de nodejs, malheureusement obsolète (0.10.x) ; et que si vous avez eu le malheur, par le passé, d'installer nodejs via le dépôt standard de Debian, cette version, même désinstallée via un bon vieux `apt-get purge nodejs`, entrera en conflit avec l'installation de nodejs 4.x, ce qui fera planter toute l'installation de Cozy. De plus, le message d'erreur que vous rencontrerez sera très bas niveau :
 ```
 update-alternatives: error: alternative link /usr/bin/node is already managed by nodejs
-dpkg: error processing package nodejs (--configure): subprocess installed post-installation script returned error exit status 
+dpkg: error processing package nodejs (--configure): subprocess installed post-installation script returned error exit status
 ```
 La solution (qui nous vient de [cette question StackOverflow](http://stackoverflow.com/questions/25094718/error-on-update-alternatives-when-installing-upgrading-nodejs-v0-10-30)) : `update-alternatives --remove-all nodejs`, qui supprime toute trace de nodejs 0.10.x de votre système et laisse ainsi la voie libre à Cozy pour installer nodejs 4.x.

--- a/src/documents/fr/host/install/install-on-digitalocean.html.md
+++ b/src/documents/fr/host/install/install-on-digitalocean.html.md
@@ -56,10 +56,10 @@ ssh root@ip.du.serveur
 
 ```
 # Importez la clé publique du dépôt Cozy
-wget -O - http://debian.cozycloud.cc/cozy.gpg.key 2>/dev/null | apt-key add -
+wget https://debian.cozycloud.cc/cozy.gpg.key -O /etc/apt/trusted.gpg.d/cozy.gpg
 
 # Ajoutez le dépôt Cozy à vos sources de logiciel
-echo 'deb http://debian.cozycloud.cc/debian jessie cozy' \
+echo 'deb https://debian.cozycloud.cc/debian jessie cozy' \
  > /etc/apt/sources.list.d/cozy.list
 
 # Installez Cozy

--- a/src/documents/fr/host/install/install-on-ubuntu.html.md
+++ b/src/documents/fr/host/install/install-on-ubuntu.html.md
@@ -34,7 +34,7 @@ Cozy a besoin d’un serveur web. Par défaut, nous installons et configurons un
     ```
 2. Importez la clé publique du dépôt
     ```
-    wget -O - https://ubuntu.cozycloud.cc/cozy.gpg.key 2>/dev/null | sudo apt-key add -
+    wget https://debian.cozycloud.cc/cozy.gpg.key -O /etc/apt/trusted.gpg.d/cozy.gpg
     ```
 3. Ajoutez le dépôt Cozy à vos sources de logiciels.
     ```


### PR DESCRIPTION
With https://github.com/cozy/cozy-debian/commit/0d4309b31821eae8a9fbdfd96b4bcdbe49d2569e, key will be shipped in a file instead of embeded in a keyring.
This PR will reflect this change on the doc to avoid conflict.